### PR TITLE
refactor: delete deprecated React.ReactChild

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -29,7 +29,7 @@ function isReactFragment(node: React.ReactNode) {
 }
 
 // Insert one space between two chinese characters automatically.
-function insertSpace(child: React.ReactChild, needInserted: boolean) {
+function insertSpace(child: React.ReactElement | string | number, needInserted: boolean) {
   // Check the child if is undefined or null.
   if (child === null || child === undefined) {
     return;
@@ -74,7 +74,7 @@ function spaceChildren(children: React.ReactNode, needInserted: boolean) {
 
   // Pass to React.Children.map to auto fill key
   return React.Children.map(childList, child =>
-    insertSpace(child as React.ReactChild, needInserted),
+    insertSpace(child as React.ReactElement | string | number, needInserted),
   );
 }
 


### PR DESCRIPTION
use React.ReactElement | string | number to replace the deprecated React.ReactChild